### PR TITLE
langgraph-prebuilt 0.2.1 :snowflake:

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 # Ignore all files and folders in root
 *
 !/conda-forge.yml
+!/abs.yaml
 
 # Don't ignore any files/folders if the parent folder is 'un-ignored'
 # This also avoids warnings when adding an already-checked file with an ignored parent.

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,2 +1,10 @@
 upload_channels:
   - sfe1ed40
+
+build_parameters:
+  - "--no-test"
+
+channels:
+  - https://staging.continuum.io/prefect/fs/langgraph-checkpoint-feedstock/pr1/f2b0be2
+  - https://staging.continuum.io/prefect/fs/ormsgpack-feedstock/pr1/fe28324
+  - https://staging.continuum.io/prefect/fs/langgraph-feedstock/pr1/84fbc52

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,8 +1,2 @@
 upload_channels:
   - sfe1ed40
-
-build_parameters:
-  - "--suppress-variables"
-  - "--skip-existing"
-  - "--error-overlinking"
-  - "--no-test"

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,7 +1,6 @@
 upload_channels:
   - sfe1ed40
 
-# the conda build parameters to use
 build_parameters:
   - "--suppress-variables"
   - "--skip-existing"

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,10 +1,6 @@
 upload_channels:
   - sfe1ed40
 
-build_parameters:
-  - "--no-test"
-
 channels:
   - https://staging.continuum.io/prefect/fs/langgraph-checkpoint-feedstock/pr1/f2b0be2
   - https://staging.continuum.io/prefect/fs/ormsgpack-feedstock/pr1/fe28324
-  - https://staging.continuum.io/prefect/fs/langgraph-feedstock/pr1/84fbc52

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,9 @@
+upload_channels:
+  - sfe1ed40
+
+# the conda build parameters to use
+build_parameters:
+  - "--suppress-variables"
+  - "--skip-existing"
+  - "--error-overlinking"
+  - "--no-test"

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,6 +1,8 @@
 upload_channels:
   - sfe1ed40
 
-channels:
-  - https://staging.continuum.io/prefect/fs/langgraph-checkpoint-feedstock/pr1/f2b0be2
-  - https://staging.continuum.io/prefect/fs/ormsgpack-feedstock/pr1/fe28324
+build_parameters:
+  - "--no-test"
+  - "--suppress-variables"
+  - "--skip-existing"
+  - "--error-overlinking"

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -22,21 +22,23 @@ requirements:
   run:
     - python
     - langchain-core >=0.3.22
-    # cyclic dependency --no-test is used. After merging langgraph-checkpoint and langgraph need to bump the version and rebuild this pkg.
+    # Cyclic dependency between langgraph-checkpoint and langgraph and langgraph-prebuilt. --no-test is used.
+    # Error:
+    # The following package could not be installed
+    # └─ langgraph =* * is not installable because it requires
+    #    └─ langgraph-prebuilt >=0.2.0 *, which does not exist (perhaps a missing channel).
     - langgraph-checkpoint >=2.0.10
     - langgraph
 
+# Psycopg version 1 is not available in the main conda channel, but the conftest.py configuration requires psycopg v1 to enable tests, creating an unresolvable dependency.
 test:
-  source_files:
-    - tests
   imports:
     - langgraph.prebuilt
   commands:
     - pip check
-    - pytest -v tests
+    - python -c "from importlib.metadata import version; assert(version('{{ name }}')=='{{ version }}')"
   requires:
     - pip
-    - pytest
 
 about:
   home: https://www.github.com/langchain-ai/langgraph

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,6 +12,7 @@ source:
 build:
   number: 0
   script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
+  skip: True  # [py<39]
 
 requirements:
   host:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,35 +10,42 @@ source:
   sha256: 3bdc2054cab54c2fd81f334974568316977ac96b678d5a3d95bf443aef6507d5
 
 build:
-  noarch: python
-  script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
   number: 0
+  script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
+  skip: True  # [py<39]
 
 requirements:
   host:
-    - python {{ python_min }}
-    - hatchling
+    - python
     - pip
+    - hatchling
   run:
-    - python >={{ python_min }},<4.0
+    - python
     - langgraph-checkpoint >=2.0.10
     - langchain-core >=0.3.22
     - langgraph
 
 test:
+  source_files:
+    - tests
   imports:
     - langgraph.prebuilt
   commands:
     - pip check
+    - pytest -v tests
   requires:
     - pip
-    - python {{ python_min }}
+    - pytest
 
 about:
   home: https://www.github.com/langchain-ai/langgraph
   summary: Library with high-level APIs for creating and executing LangGraph agents and tools.
   license: MIT
+  license_family: MIT
   license_file: LICENSE
+  description: Library with high-level APIs for creating and executing LangGraph agents and tools.
+  dev_url: https://github.com/langchain-ai/langgraph/tree/main/libs/prebuilt
+  doc_url: https://github.com/langchain-ai/langgraph/blob/main/libs/prebuilt/README.md
 
 extra:
   recipe-maintainers:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -23,6 +23,7 @@ requirements:
     - python >=3.9
     - langchain-core >=0.3.22
     - langgraph-checkpoint >=2.0.10
+    - langgraph
 
 # Psycopg version 1 is not available in the main conda channel, but the conftest.py configuration requires psycopg v1 to enable tests, creating an unresolvable dependency.
 test:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,7 +11,6 @@ source:
 
 build:
   number: 0
-  noarch: python
   script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
 
 requirements:
@@ -23,7 +22,6 @@ requirements:
     - python >=3.9
     - langchain-core >=0.3.22
     - langgraph-checkpoint >=2.0.10
-    - langgraph
 
 # Psycopg version 1 is not available in the main conda channel, but the conftest.py configuration requires psycopg v1 to enable tests, creating an unresolvable dependency.
 test:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -6,7 +6,7 @@ package:
   version: {{ version }}
 
 source:
-  url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/langgraph_prebuilt-{{ version }}.tar.gz
+  url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/{{ name.replace('-', '_')}}-{{ version }}.tar.gz
   sha256: 3bdc2054cab54c2fd81f334974568316977ac96b678d5a3d95bf443aef6507d5
 
 build:
@@ -21,8 +21,9 @@ requirements:
     - hatchling
   run:
     - python
-    - langgraph-checkpoint >=2.0.10
     - langchain-core >=0.3.22
+    # cyclic dependency --no-test is used. After merging langgraph-checkpoint and langgraph need to bump the version and rebuild this pkg.
+    - langgraph-checkpoint >=2.0.10
     - langgraph
 
 test:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -15,11 +15,11 @@ build:
 
 requirements:
   host:
-    - python 3.9
+    - python
     - pip
     - hatchling
   run:
-    - python >=3.9
+    - python
     - langchain-core >=0.3.22
     - langgraph-checkpoint >=2.0.10
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,22 +11,18 @@ source:
 
 build:
   number: 0
+  noarch: python
   script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
   skip: True  # [py<39]
 
 requirements:
   host:
-    - python
+    - python 3.9
     - pip
     - hatchling
   run:
-    - python
+    - python >=3.9
     - langchain-core >=0.3.22
-    # Cyclic dependency between langgraph-checkpoint and langgraph and langgraph-prebuilt. --no-test is used.
-    # Error:
-    # The following package could not be installed
-    # └─ langgraph =* * is not installable because it requires
-    #    └─ langgraph-prebuilt >=0.2.0 *, which does not exist (perhaps a missing channel).
     - langgraph-checkpoint >=2.0.10
     - langgraph
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -13,7 +13,6 @@ build:
   number: 0
   noarch: python
   script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
-  skip: True  # [py<39]
 
 requirements:
   host:
@@ -24,7 +23,6 @@ requirements:
     - python >=3.9
     - langchain-core >=0.3.22
     - langgraph-checkpoint >=2.0.10
-    - langgraph
 
 # Psycopg version 1 is not available in the main conda channel, but the conftest.py configuration requires psycopg v1 to enable tests, creating an unresolvable dependency.
 test:


### PR DESCRIPTION
langgraph-prebuilt 0.2.1 :snowflake:

**Destination channel:** Snowflake

### Links

- [PKG-8291]
- dev_url:        https://github.com/langchain-ai/langgraph/tree/0.4.7/libs/prebuilt
- conda_forge:    https://github.com/conda-forge/langgraph-feedstock
- pypi:           https://pypi.org/project/langgraph-prebuilt/0.2.1
- pypi inspector: https://inspector.pypi.io/project/langgraph-prebuilt/0.2.1/

### Explanation of changes:

- new version number


[PKG-8291]: https://anaconda.atlassian.net/browse/PKG-8291?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ