### PR TITLE
langgraph-prebuilt 0.2.1 (tests) :snowflake:

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,8 +1,2 @@
 upload_channels:
   - sfe1ed40
-
-build_parameters:
-  - "--no-test"
-  - "--suppress-variables"
-  - "--skip-existing"
-  - "--error-overlinking"

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -8,13 +8,20 @@ package:
 source:
   url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/{{ name.replace('-', '_')}}-{{ version }}.tar.gz
   sha256: 3bdc2054cab54c2fd81f334974568316977ac96b678d5a3d95bf443aef6507d5
+  patches:
+    #E   ModuleNotFoundError: No module named 'psycopg-pool'
+    #E   ModuleNotFoundError: No module named 'langgraph-checkpoint-postgres'
+    - patches/0001-removed-the-pool-and-unavailable-checkpointers.patch
 
 build:
-  number: 0
+  number: 1
   script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
   skip: True  # [py<39]
 
 requirements:
+  build:
+    - patch  # [not win]
+    - m2-patch  # [win]
   host:
     - python
     - pip
@@ -23,16 +30,26 @@ requirements:
     - python
     - langchain-core >=0.3.22
     - langgraph-checkpoint >=2.0.10
+    - langgraph
 
-# Psycopg version 1 is not available in the main conda channel, but the conftest.py configuration requires psycopg v1 to enable tests, creating an unresolvable dependency.
+# E   ModuleNotFoundError: No module named 'syrupy'
+{% set ignore_tests = " --ignore=tests/test_react_agent_graph.py" %}
+
 test:
+  source_files:
+    - tests
   imports:
     - langgraph.prebuilt
   commands:
     - pip check
     - python -c "from importlib.metadata import version; assert(version('{{ name }}')=='{{ version }}')"
+    - pytest -v {{ ignore_tests }} tests
   requires:
     - pip
+    - pytest
+    - pytest-asyncio
+    - pytest-mock
+    - psycopg
 
 about:
   home: https://www.github.com/langchain-ai/langgraph

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -9,8 +9,9 @@ source:
   url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/{{ name.replace('-', '_')}}-{{ version }}.tar.gz
   sha256: 3bdc2054cab54c2fd81f334974568316977ac96b678d5a3d95bf443aef6507d5
   patches:
-    #E   ModuleNotFoundError: No module named 'psycopg-pool'
-    #E   ModuleNotFoundError: No module named 'langgraph-checkpoint-postgres'
+    # E   ModuleNotFoundError: No module named 'psycopg-pool'
+    # E   ModuleNotFoundError: No module named 'langgraph-checkpoint-postgres'
+    # E   ModuleNotFoundError: No module named 'langgraph-checkpoint-sqlite'
     - patches/0001-removed-the-pool-and-unavailable-checkpointers.patch
 
 build:

--- a/recipe/patches/0001-removed-the-pool-and-unavailable-checkpointers.patch
+++ b/recipe/patches/0001-removed-the-pool-and-unavailable-checkpointers.patch
@@ -1,0 +1,232 @@
+From 2ba8035f4d5ee975f21d2ec8a1621608024ce670 Mon Sep 17 00:00:00 2001
+From: Andrii Osipov <aosipov@anaconda.com>
+Date: Mon, 2 Jun 2025 02:18:40 -0700
+Subject: [PATCH] removed the pool and unavailable checkpointers
+
+---
+ tests/conftest.py              | 128 ++++++++++++++++-----------------
+ tests/conftest_checkpointer.py |  10 +--
+ tests/conftest_store.py        |   2 +-
+ 3 files changed, 70 insertions(+), 70 deletions(-)
+
+diff --git a/tests/conftest.py b/tests/conftest.py
+index 8ba0771..f5cc897 100644
+--- a/tests/conftest.py
++++ b/tests/conftest.py
+@@ -10,23 +10,23 @@ from langgraph.checkpoint.base import BaseCheckpointSaver
+ from langgraph.store.base import BaseStore
+ from tests.conftest_checkpointer import (
+     _checkpointer_memory,
+-    _checkpointer_postgres,
+-    _checkpointer_postgres_aio,
+-    _checkpointer_postgres_aio_pipe,
+-    _checkpointer_postgres_aio_pool,
+-    _checkpointer_postgres_pipe,
+-    _checkpointer_postgres_pool,
+-    _checkpointer_sqlite,
+-    _checkpointer_sqlite_aio,
++    #_checkpointer_postgres,
++    #_checkpointer_postgres_aio,
++    #_checkpointer_postgres_aio_pipe,
++    #_checkpointer_postgres_aio_pool,
++    #_checkpointer_postgres_pipe,
++    #_checkpointer_postgres_pool,
++    #_checkpointer_sqlite,
++    #_checkpointer_sqlite_aio,
+ )
+ from tests.conftest_store import (
+     _store_memory,
+-    _store_postgres,
+-    _store_postgres_aio,
+-    _store_postgres_aio_pipe,
+-    _store_postgres_aio_pool,
+-    _store_postgres_pipe,
+-    _store_postgres_pool,
++    #_store_postgres,
++    #_store_postgres_aio,
++    #_store_postgres_aio_pipe,
++    #_store_postgres_aio_pool,
++    #_store_postgres_pipe,
++    #_store_postgres_pool,
+ )
+ 
+ pytest.register_assert_rewrite("tests.memory_assert")
+@@ -64,15 +64,15 @@ def sync_store(request: pytest.FixtureRequest) -> Iterator[BaseStore]:
+     elif store_name == "in_memory":
+         with _store_memory() as store:
+             yield store
+-    elif store_name == "postgres":
+-        with _store_postgres() as store:
+-            yield store
+-    elif store_name == "postgres_pipe":
+-        with _store_postgres_pipe() as store:
+-            yield store
+-    elif store_name == "postgres_pool":
+-        with _store_postgres_pool() as store:
+-            yield store
++    #elif store_name == "postgres":
++    #    with _store_postgres() as store:
++    #        yield store
++    #elif store_name == "postgres_pipe":
++    #    with _store_postgres_pipe() as store:
++    #        yield store
++    #elif store_name == "postgres_pool":
++    #    with _store_postgres_pool() as store:
++    #        yield store
+     else:
+         raise NotImplementedError(f"Unknown store {store_name}")
+ 
+@@ -88,15 +88,15 @@ async def async_store(request: pytest.FixtureRequest) -> AsyncIterator[BaseStore
+     elif store_name == "in_memory":
+         with _store_memory() as store:
+             yield store
+-    elif store_name == "postgres_aio":
+-        async with _store_postgres_aio() as store:
+-            yield store
+-    elif store_name == "postgres_aio_pipe":
+-        async with _store_postgres_aio_pipe() as store:
+-            yield store
+-    elif store_name == "postgres_aio_pool":
+-        async with _store_postgres_aio_pool() as store:
+-            yield store
++    #elif store_name == "postgres_aio":
++    #    async with _store_postgres_aio() as store:
++    #        yield store
++    #elif store_name == "postgres_aio_pipe":
++    #    async with _store_postgres_aio_pipe() as store:
++    #        yield store
++    #elif store_name == "postgres_aio_pool":
++    #    async with _store_postgres_aio_pool() as store:
++    #        yield store
+     else:
+         raise NotImplementedError(f"Unknown store {store_name}")
+ 
+@@ -105,10 +105,10 @@ async def async_store(request: pytest.FixtureRequest) -> AsyncIterator[BaseStore
+     scope="function",
+     params=[
+         "memory",
+-        "sqlite",
+-        "postgres",
+-        "postgres_pipe",
+-        "postgres_pool",
++        #"sqlite",
++        #"postgres",
++        #"postgres_pipe",
++        #"postgres_pool",
+     ],
+ )
+ def sync_checkpointer(
+@@ -118,18 +118,18 @@ def sync_checkpointer(
+     if checkpointer_name == "memory":
+         with _checkpointer_memory() as checkpointer:
+             yield checkpointer
+-    elif checkpointer_name == "sqlite":
+-        with _checkpointer_sqlite() as checkpointer:
+-            yield checkpointer
+-    elif checkpointer_name == "postgres":
+-        with _checkpointer_postgres() as checkpointer:
+-            yield checkpointer
+-    elif checkpointer_name == "postgres_pipe":
+-        with _checkpointer_postgres_pipe() as checkpointer:
+-            yield checkpointer
+-    elif checkpointer_name == "postgres_pool":
+-        with _checkpointer_postgres_pool() as checkpointer:
+-            yield checkpointer
++    #elif checkpointer_name == "sqlite":
++    #    with _checkpointer_sqlite() as checkpointer:
++    #        yield checkpointer
++    #elif checkpointer_name == "postgres":
++    #    with _checkpointer_postgres() as checkpointer:
++    #        yield checkpointer
++    #elif checkpointer_name == "postgres_pipe":
++    #    with _checkpointer_postgres_pipe() as checkpointer:
++    #        yield checkpointer
++    #elif checkpointer_name == "postgres_pool":
++    #    with _checkpointer_postgres_pool() as checkpointer:
++    #        yield checkpointer
+     else:
+         raise NotImplementedError(f"Unknown checkpointer: {checkpointer_name}")
+ 
+@@ -138,10 +138,10 @@ def sync_checkpointer(
+     scope="function",
+     params=[
+         "memory",
+-        "sqlite_aio",
+-        "postgres_aio",
+-        "postgres_aio_pipe",
+-        "postgres_aio_pool",
++        #"sqlite_aio",
++        #"postgres_aio",
++        #"postgres_aio_pipe",
++        #"postgres_aio_pool",
+     ],
+ )
+ async def async_checkpointer(
+@@ -151,17 +151,17 @@ async def async_checkpointer(
+     if checkpointer_name == "memory":
+         with _checkpointer_memory() as checkpointer:
+             yield checkpointer
+-    elif checkpointer_name == "sqlite_aio":
+-        async with _checkpointer_sqlite_aio() as checkpointer:
+-            yield checkpointer
+-    elif checkpointer_name == "postgres_aio":
+-        async with _checkpointer_postgres_aio() as checkpointer:
+-            yield checkpointer
+-    elif checkpointer_name == "postgres_aio_pipe":
+-        async with _checkpointer_postgres_aio_pipe() as checkpointer:
+-            yield checkpointer
+-    elif checkpointer_name == "postgres_aio_pool":
+-        async with _checkpointer_postgres_aio_pool() as checkpointer:
+-            yield checkpointer
++    #elif checkpointer_name == "sqlite_aio":
++    #    async with _checkpointer_sqlite_aio() as checkpointer:
++    #        yield checkpointer
++    #elif checkpointer_name == "postgres_aio":
++    #    async with _checkpointer_postgres_aio() as checkpointer:
++    #        yield checkpointer
++    #elif checkpointer_name == "postgres_aio_pipe":
++    #    async with _checkpointer_postgres_aio_pipe() as checkpointer:
++    #        yield checkpointer
++    #elif checkpointer_name == "postgres_aio_pool":
++    #    async with _checkpointer_postgres_aio_pool() as checkpointer:
++    #        yield checkpointer
+     else:
+         raise NotImplementedError(f"Unknown checkpointer: {checkpointer_name}")
+diff --git a/tests/conftest_checkpointer.py b/tests/conftest_checkpointer.py
+index b3c7820..93611da 100644
+--- a/tests/conftest_checkpointer.py
++++ b/tests/conftest_checkpointer.py
+@@ -4,12 +4,12 @@ from uuid import uuid4
+ 
+ import pytest
+ from psycopg import AsyncConnection, Connection
+-from psycopg_pool import AsyncConnectionPool, ConnectionPool
++#from psycopg_pool import AsyncConnectionPool, ConnectionPool
+ 
+-from langgraph.checkpoint.postgres import PostgresSaver
+-from langgraph.checkpoint.postgres.aio import AsyncPostgresSaver
+-from langgraph.checkpoint.sqlite import SqliteSaver
+-from langgraph.checkpoint.sqlite.aio import AsyncSqliteSaver
++#from langgraph.checkpoint.postgres import PostgresSaver
++#from langgraph.checkpoint.postgres.aio import AsyncPostgresSaver
++#from langgraph.checkpoint.sqlite import SqliteSaver
++#from langgraph.checkpoint.sqlite.aio import AsyncSqliteSaver
+ from tests.memory_assert import MemorySaverAssertImmutable
+ 
+ DEFAULT_POSTGRES_URI = "postgres://postgres:postgres@localhost:5442/"
+diff --git a/tests/conftest_store.py b/tests/conftest_store.py
+index 9d047a8..30ee02c 100644
+--- a/tests/conftest_store.py
++++ b/tests/conftest_store.py
+@@ -6,7 +6,7 @@ import pytest
+ from psycopg import AsyncConnection, Connection
+ 
+ from langgraph.store.memory import InMemoryStore
+-from langgraph.store.postgres import AsyncPostgresStore, PostgresStore
++#from langgraph.store.postgres import AsyncPostgresStore, PostgresStore
+ 
+ DEFAULT_POSTGRES_URI = "postgres://postgres:postgres@localhost:5442/"
+ 
+-- 
+2.39.3 (Apple Git-146)
+


### PR DESCRIPTION
langgraph-prebuilt 0.2.1 :snowflake:

**Destination channel:** Snowflake

### Links

- [PKG-8291]
- dev_url:        https://github.com/langchain-ai/langgraph/tree/0.4.7/libs/prebuilt
- conda_forge:    https://github.com/conda-forge/langgraph-feedstock
- pypi:           https://pypi.org/project/langgraph-prebuilt/0.2.1
- pypi inspector: https://inspector.pypi.io/project/langgraph-prebuilt/0.2.1/

### Explanation of changes:

- new version number


[PKG-8291]: https://anaconda.atlassian.net/browse/PKG-8291?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ