### PR TITLE
langgraph-prebuilt 1.0.1 rebuild

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,2 +1,0 @@
-upload_channels:
-  - sfe1ed40

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "langgraph-prebuilt" %}
-{% set version = "0.6.4" %}
+{% set version = "1.0.1" %}
 
 package:
   name: {{ name|lower }}
@@ -7,17 +7,17 @@ package:
 
 source:
   url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/{{ name.replace('-', '_')}}-{{ version }}.tar.gz
-  sha256: e9e53b906ee5df46541d1dc5303239e815d3ec551e52bb03dd6463acc79ec28f
-  patches:
+  sha256: ecbfb9024d9d7ed9652dde24eef894650aaab96bf79228e862c503e2a060b469
+  # patches:
     # E   ModuleNotFoundError: No module named 'psycopg-pool'
     # E   ModuleNotFoundError: No module named 'langgraph-checkpoint-postgres'
     # E   ModuleNotFoundError: No module named 'langgraph-checkpoint-sqlite'
-    - patches/0001-removed-the-pool-and-unavailable-checkpointers.patch
+    # - patches/0001-removed-the-pool-and-unavailable-checkpointers.patch
 
 build:
-  number: 1
+  number: 0
   script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
-  skip: True  # [py<39]
+  skip: True  # [py<310]
 
 requirements:
   host:
@@ -27,29 +27,37 @@ requirements:
   run:
     - python
     - langchain-core >=0.3.67
-    - langgraph-checkpoint >=2.1.0,<3.0.0
-    - langgraph
+    - langgraph-checkpoint >=2.1.0,<4.0.0
+    # Commented out due to cycle dependency with langgraph which is not on main yet.
+    # - langgraph
     # https://github.com/langchain-ai/langgraph/issues/5086
     - langchain
 
-# E   ModuleNotFoundError: No module named 'syrupy'
-{% set ignore_tests = " --ignore=tests/test_react_agent_graph.py" %}
+# Temporarily comment out test section due to cycle dependency with langgraph.
+# Package needs to be rebuilt with tests after langgraph release.
 
-test:
-  source_files:
-    - tests
-  imports:
-    - langgraph.prebuilt
-  commands:
-    - pip check
-    - python -c "from importlib.metadata import version; assert(version('{{ name }}')=='{{ version }}')"
-    - pytest -v {{ ignore_tests }} tests
-  requires:
-    - pip
-    - pytest
-    - pytest-asyncio
-    - pytest-mock
-    - psycopg
+# E   ModuleNotFoundError: No module named 'syrupy'
+# {% set ignore_tests = " --ignore=tests/test_react_agent_graph.py" %}
+
+# test:
+#   source_files:
+#     - tests
+#   imports:
+#     - langgraph.prebuilt
+#     - langgraph.prebuilt.chat_agent_executor
+#     - langgraph.prebuilt.interrupt
+#     - langgraph.prebuilt.tool_node
+#     - langgraph.prebuilt.tool_validator
+#   commands:
+#     - pip check
+#     - python -c "from importlib.metadata import version; assert(version('{{ name }}')=='{{ version }}')"
+#     - pytest -v {{ ignore_tests }} tests
+#   requires:
+#     - pip
+#     - pytest
+#     - pytest-asyncio
+#     - pytest-mock
+#     - psycopg
 
 about:
   home: https://www.github.com/langchain-ai/langgraph

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -15,7 +15,7 @@ source:
     - patches/0001-removed-the-pool-and-unavailable-checkpointers.patch
 
 build:
-  number: 1
+  number: 0
   script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
   skip: True  # [py<310]
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -8,14 +8,14 @@ package:
 source:
   url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/{{ name.replace('-', '_')}}-{{ version }}.tar.gz
   sha256: ecbfb9024d9d7ed9652dde24eef894650aaab96bf79228e862c503e2a060b469
-  # patches:
+  patches:
     # E   ModuleNotFoundError: No module named 'psycopg-pool'
     # E   ModuleNotFoundError: No module named 'langgraph-checkpoint-postgres'
     # E   ModuleNotFoundError: No module named 'langgraph-checkpoint-sqlite'
-    # - patches/0001-removed-the-pool-and-unavailable-checkpointers.patch
+    - patches/0001-removed-the-pool-and-unavailable-checkpointers.patch
 
 build:
-  number: 0
+  number: 1
   script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
   skip: True  # [py<310]
 
@@ -28,36 +28,32 @@ requirements:
     - python
     - langchain-core >=0.3.67
     - langgraph-checkpoint >=2.1.0,<4.0.0
-    # Commented out due to cycle dependency with langgraph which is not on main yet.
-    # - langgraph
+    - langgraph
     # https://github.com/langchain-ai/langgraph/issues/5086
     - langchain
 
-# Temporarily comment out test section due to cycle dependency with langgraph.
-# Package needs to be rebuilt with tests after langgraph release.
-
 # E   ModuleNotFoundError: No module named 'syrupy'
-# {% set ignore_tests = " --ignore=tests/test_react_agent_graph.py" %}
+{% set ignore_tests = " --ignore=tests/test_react_agent_graph.py" %}
 
-# test:
-#   source_files:
-#     - tests
-#   imports:
-#     - langgraph.prebuilt
-#     - langgraph.prebuilt.chat_agent_executor
-#     - langgraph.prebuilt.interrupt
-#     - langgraph.prebuilt.tool_node
-#     - langgraph.prebuilt.tool_validator
-#   commands:
-#     - pip check
-#     - python -c "from importlib.metadata import version; assert(version('{{ name }}')=='{{ version }}')"
-#     - pytest -v {{ ignore_tests }} tests
-#   requires:
-#     - pip
-#     - pytest
-#     - pytest-asyncio
-#     - pytest-mock
-#     - psycopg
+test:
+  source_files:
+    - tests
+  imports:
+    - langgraph.prebuilt
+    - langgraph.prebuilt.chat_agent_executor
+    - langgraph.prebuilt.interrupt
+    - langgraph.prebuilt.tool_node
+    - langgraph.prebuilt.tool_validator
+  commands:
+    - pip check
+    - python -c "from importlib.metadata import version; assert(version('{{ name }}')=='{{ version }}')"
+    - pytest -v {{ ignore_tests }} tests
+  requires:
+    - pip
+    - pytest
+    - pytest-asyncio
+    - pytest-mock
+    - psycopg
 
 about:
   home: https://www.github.com/langchain-ai/langgraph

--- a/recipe/patches/0001-removed-the-pool-and-unavailable-checkpointers.patch
+++ b/recipe/patches/0001-removed-the-pool-and-unavailable-checkpointers.patch
@@ -1,20 +1,19 @@
-From c56806857b1f859ba08cd504e11040d69ab5dc0a Mon Sep 17 00:00:00 2001
+From 0123aa9f767dc795ff85a3a1b8daeed879e10d4b Mon Sep 17 00:00:00 2001
 From: Patryk Kups <pkups@anaconda.com>
-Date: Mon, 6 Oct 2025 17:42:28 +0200
+Date: Tue, 28 Oct 2025 09:10:14 +0100
 Subject: [PATCH] patch
 
 ---
  tests/conftest.py              | 28 ++++++++++++++--------------
  tests/conftest_checkpointer.py | 10 +++++-----
- tests/conftest_store.py        |  2 +-
- 3 files changed, 20 insertions(+), 20 deletions(-)
+ 2 files changed, 19 insertions(+), 19 deletions(-)
 
 diff --git a/tests/conftest.py b/tests/conftest.py
-index bb44383..dee92ca 100644
+index 72ee4ad..12a38b1 100644
 --- a/tests/conftest.py
 +++ b/tests/conftest.py
-@@ -9,23 +9,23 @@ from langgraph.checkpoint.base import BaseCheckpointSaver
- from langgraph.store.base import BaseStore
+@@ -9,23 +9,23 @@ from pytest_mock import MockerFixture
+ 
  from tests.conftest_checkpointer import (
      _checkpointer_memory,
 -    _checkpointer_postgres,
@@ -52,15 +51,12 @@ index bb44383..dee92ca 100644
  
  pytest.register_assert_rewrite("tests.memory_assert")
 diff --git a/tests/conftest_checkpointer.py b/tests/conftest_checkpointer.py
-index b3c7820..5949e54 100644
+index c71e46c..e06e950 100644
 --- a/tests/conftest_checkpointer.py
 +++ b/tests/conftest_checkpointer.py
-@@ -4,12 +4,12 @@ from uuid import uuid4
- 
- import pytest
- from psycopg import AsyncConnection, Connection
--from psycopg_pool import AsyncConnectionPool, ConnectionPool
-+# from psycopg_pool import AsyncConnectionPool, ConnectionPool
+@@ -1,12 +1,12 @@
+ from contextlib import asynccontextmanager, contextmanager
+ from uuid import uuid4
  
 -from langgraph.checkpoint.postgres import PostgresSaver
 -from langgraph.checkpoint.postgres.aio import AsyncPostgresSaver
@@ -70,21 +66,11 @@ index b3c7820..5949e54 100644
 +# from langgraph.checkpoint.postgres.aio import AsyncPostgresSaver
 +# from langgraph.checkpoint.sqlite import SqliteSaver
 +# from langgraph.checkpoint.sqlite.aio import AsyncSqliteSaver
- from tests.memory_assert import MemorySaverAssertImmutable
- 
- DEFAULT_POSTGRES_URI = "postgres://postgres:postgres@localhost:5442/"
-diff --git a/tests/conftest_store.py b/tests/conftest_store.py
-index 9d047a8..02bbce0 100644
---- a/tests/conftest_store.py
-+++ b/tests/conftest_store.py
-@@ -6,7 +6,7 @@ import pytest
  from psycopg import AsyncConnection, Connection
+-from psycopg_pool import AsyncConnectionPool, ConnectionPool
++# from psycopg_pool import AsyncConnectionPool, ConnectionPool
  
- from langgraph.store.memory import InMemoryStore
--from langgraph.store.postgres import AsyncPostgresStore, PostgresStore
-+# from langgraph.store.postgres import AsyncPostgresStore, PostgresStore
- 
- DEFAULT_POSTGRES_URI = "postgres://postgres:postgres@localhost:5442/"
+ from tests.memory_assert import MemorySaverAssertImmutable
  
 -- 
 2.39.5 (Apple Git-154)

--- a/recipe/patches/0001-removed-the-pool-and-unavailable-checkpointers.patch
+++ b/recipe/patches/0001-removed-the-pool-and-unavailable-checkpointers.patch
@@ -1,12 +1,13 @@
-From 0123aa9f767dc795ff85a3a1b8daeed879e10d4b Mon Sep 17 00:00:00 2001
+From 0a1447fbf6ffbff7866f1d2ec840b3e0011b9b8f Mon Sep 17 00:00:00 2001
 From: Patryk Kups <pkups@anaconda.com>
-Date: Tue, 28 Oct 2025 09:10:14 +0100
+Date: Tue, 28 Oct 2025 12:13:08 +0100
 Subject: [PATCH] patch
 
 ---
  tests/conftest.py              | 28 ++++++++++++++--------------
  tests/conftest_checkpointer.py | 10 +++++-----
- 2 files changed, 19 insertions(+), 19 deletions(-)
+ tests/conftest_store.py        |  2 +-
+ 3 files changed, 20 insertions(+), 20 deletions(-)
 
 diff --git a/tests/conftest.py b/tests/conftest.py
 index 72ee4ad..12a38b1 100644
@@ -72,6 +73,19 @@ index c71e46c..e06e950 100644
  
  from tests.memory_assert import MemorySaverAssertImmutable
  
+diff --git a/tests/conftest_store.py b/tests/conftest_store.py
+index 4ae8c24..25ae3c0 100644
+--- a/tests/conftest_store.py
++++ b/tests/conftest_store.py
+@@ -2,7 +2,7 @@ from contextlib import asynccontextmanager, contextmanager
+ from uuid import uuid4
+ 
+ from langgraph.store.memory import InMemoryStore
+-from langgraph.store.postgres import AsyncPostgresStore, PostgresStore
++# from langgraph.store.postgres import AsyncPostgresStore, PostgresStore
+ from psycopg import AsyncConnection, Connection
+ 
+ DEFAULT_POSTGRES_URI = "postgres://postgres:postgres@localhost:5442/"
 -- 
 2.39.5 (Apple Git-154)
 


### PR DESCRIPTION
langgraph-prebuilt 1.0.1 rebuild

**Destination channel:** Defaults

### Links

- [PKG-10376]
- dev_url:        https://github.com/langchain-ai/langgraph/tree/prebuilt==1.0.1
- conda_forge:    https://github.com/conda-forge/langgraph-prebuilt-feedstock
- pypi:           https://pypi.org/project/langgraph-prebuilt/1.0.1
- pypi inspector: https://inspector.pypi.io/project/langgraph-prebuilt/1.0.1

### Explanation of changes:

- rebuild due to cycle dependency


[PKG-10376]: https://anaconda.atlassian.net/browse/PKG-10376?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ