### PR TITLE
langgraph-prebuilt 1.1.0 (fix langgraph.stream import)

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -15,7 +15,7 @@ source:
     - patches/0001-removed-the-pool-and-unavailable-checkpointers.patch
 
 build:
-  number: 0
+  number: 1
   script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
   skip: true  # [py<310]
 
@@ -29,6 +29,9 @@ requirements:
     # https://github.com/langchain-ai/langgraph/blob/1.2.1/libs/prebuilt/pyproject.toml
     - langchain-core >=1.3.1
     - langgraph-checkpoint >=2.1.0,<5.0.0
+    # Must be bundled with langgraph - don`t remove this dependency!!!!!
+    # Read PyPi description -> https://pypi.org/project/langgraph-prebuilt/#description
+    - langgraph
 
 # E   ModuleNotFoundError: No module named 'syrupy'
 {% set ignore_tests = " --ignore=tests/test_react_agent_graph.py" %}


### PR DESCRIPTION
langgraph-prebuilt 1.1.0 (fix langgraph.stream import)

**Destination channel:**  defaults

### Links

- [PKG-14967]
- dev_url:        https://github.com/langchain-ai/langgraph/tree/prebuilt==1.1.0
- conda_forge:    https://github.com/conda-forge/langgraph-prebuilt-feedstock
- pypi:           https://pypi.org/project/langgraph-prebuilt/1.1.0
- pypi inspector: https://inspector.pypi.io/project/langgraph-prebuilt/1.1.0

### Explanation of changes:

- **langgraph-prebuilt==1.1.0** has code importing **langgraph.stream**, which comes from the langgraph package. 


[PKG-14967]: https://anaconda.atlassian.net/browse/PKG-14967?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ